### PR TITLE
(chore) Add pytest and pylint to setup.py extra_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ setup(
     entry_points={
         'console_scripts': ['harbor=lib.cli:cli']
     },
+    extras_require={
+        'develop': ['pytest', 'pylint'],
+    },
     url='',
     author='Srishan Bhattarai',
     author_email='srishanbhattarai@gmail.com',


### PR DESCRIPTION
After I installed the dependencies I found out that `pytest` was not installed. Thus, adding it to setup.py

Also, added in `pylint`.